### PR TITLE
Remove Circular Dependencies

### DIFF
--- a/src/web/call_hierarchy_provider/call_hierarchy_builder.ts
+++ b/src/web/call_hierarchy_provider/call_hierarchy_builder.ts
@@ -6,7 +6,7 @@ import { SymbolInfo } from '../user_symbol/SymbolInfo';
 import { bisectRight } from '../algorithm';
 import { CallHrchyInfo } from './CallHrchyInfo';
 
-import { updateInfo } from '../entry/listen_update';
+import { updateInfo } from '../entry/common';
 
 function buildCallHierarchyItem(info: SymbolInfo): vscode.CallHierarchyItem {
   const detail =

--- a/src/web/call_hierarchy_provider/call_hierarchy_provider.ts
+++ b/src/web/call_hierarchy_provider/call_hierarchy_provider.ts
@@ -4,7 +4,7 @@ import { clValidWithColonSharp, CL_MODE } from '../cl_util';
 import { DocSymbolInfo } from '../user_symbol/DocSymbolInfo';
 import { CallHrchyInfo } from './CallHrchyInfo';
 
-import { updateInfo } from '../entry/listen_update';
+import { updateInfo } from '../entry/common';
 
 function getCallHierarchyCallsByCallHierarchyItem(
   item: vscode.CallHierarchyItem,

--- a/src/web/comp_item_provider/comp_item_provider.ts
+++ b/src/web/comp_item_provider/comp_item_provider.ts
@@ -5,7 +5,7 @@ import { bisectRight } from '../algorithm';
 import { UserSymbols } from './UserSymbols';
 import { genAllOriSymbols } from './comp_item_ori_builder';
 
-import { updateInfo } from '../entry/listen_update';
+import { updateInfo } from '../entry/common';
 
 // default completion item's word range does not include the '-' character, so we need to reset it
 // @sideEffect: compItems:vscode.CompletionItem[]

--- a/src/web/definition_provider/def_provider.ts
+++ b/src/web/definition_provider/def_provider.ts
@@ -3,8 +3,7 @@ import * as vscode from 'vscode';
 import { CL_MODE, clValidWithColonSharp } from '../cl_util';
 import { isIntExcludedRanges, isQuote, isRangeIntExcludedRanges } from '../user_symbol/collect_symbol_util';
 
-import { updateInfo } from '../entry/listen_update';
-import { workspaceConfig } from '../entry/common';
+import { updateInfo, workspaceConfig } from '../entry/common';
 
 function getDefinitionProvider() {
   const definitionProvider = vscode.languages.registerDefinitionProvider(

--- a/src/web/definition_provider/def_provider.ts
+++ b/src/web/definition_provider/def_provider.ts
@@ -4,7 +4,7 @@ import { CL_MODE, clValidWithColonSharp } from '../cl_util';
 import { isIntExcludedRanges, isQuote, isRangeIntExcludedRanges } from '../user_symbol/collect_symbol_util';
 
 import { updateInfo } from '../entry/listen_update';
-import { workspaceConfig } from '../entry/init';
+import { workspaceConfig } from '../entry/common';
 
 function getDefinitionProvider() {
   const definitionProvider = vscode.languages.registerDefinitionProvider(

--- a/src/web/doc_symbol_provider/doc_symbol_provider.ts
+++ b/src/web/doc_symbol_provider/doc_symbol_provider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 
 import { CL_MODE } from '../cl_util';
 
-import { updateInfo } from '../entry/listen_update';
+import { updateInfo } from '../entry/common';
 import { triggerUpdateSymbol } from '../entry/init';
 
 function getDocumentSymbolProvider() {

--- a/src/web/doc_symbol_provider/doc_symbol_provider.ts
+++ b/src/web/doc_symbol_provider/doc_symbol_provider.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { CL_MODE } from '../cl_util';
 
 import { updateInfo } from '../entry/common';
-import { triggerUpdateSymbol } from '../entry/init';
+import { triggerUpdateSymbol } from '../entry/listen_update';
 
 function getDocumentSymbolProvider() {
   const documentSymbolProvider = vscode.languages.registerDocumentSymbolProvider(

--- a/src/web/entry/UpdateCache.ts
+++ b/src/web/entry/UpdateCache.ts
@@ -1,7 +1,7 @@
 
 class UpdateCache {
   // {offset: [line, char]}
-  public readonly cacheDocumentPosition: Record<number, [number, number]> = {};
+  public cacheDocumentPosition: Record<number, [number, number]> = {};
 
   constructor() {
 

--- a/src/web/entry/UpdateCache.ts
+++ b/src/web/entry/UpdateCache.ts
@@ -6,6 +6,10 @@ class UpdateCache {
   constructor() {
 
   }
+
+  reset() {
+    this.cacheDocumentPosition = {};
+  }
 }
 
 export { UpdateCache };

--- a/src/web/entry/UpdateInfo.ts
+++ b/src/web/entry/UpdateInfo.ts
@@ -19,6 +19,17 @@ class UpdateInfo {
   constructor() {
 
   }
+
+  reset() {
+    this.currDocSymbolInfo = undefined;
+    this.currDocumentSymbol = [];
+    this.currUserSymbols = undefined;
+    this.currSemanticTokens = undefined;
+    this.prevSemanticTokens = undefined;
+    this.callHierarchyInfo = undefined;
+    this.needColorDict = {};
+    this.globalOrderedRanges = [];
+  }
 }
 
 export { UpdateInfo };

--- a/src/web/entry/common.ts
+++ b/src/web/entry/common.ts
@@ -1,0 +1,14 @@
+
+import { UpdateInfo } from './UpdateInfo';
+import { UpdateCache } from './UpdateCache';
+import { WorkspaceConfig } from './WorkspaceConfig';
+
+const needUpdateSet: Set<string> = new Set();
+
+const updateCache = new UpdateCache();
+
+const updateInfo = new UpdateInfo();
+
+const workspaceConfig: WorkspaceConfig = new WorkspaceConfig();
+
+export {needUpdateSet, updateCache, updateInfo, workspaceConfig};

--- a/src/web/entry/common.ts
+++ b/src/web/entry/common.ts
@@ -3,9 +3,9 @@ import { UpdateInfo } from './UpdateInfo';
 import { UpdateCache } from './UpdateCache';
 import { WorkspaceConfig } from './WorkspaceConfig';
 
-const needUpdateSet: Set<string> = new Set();
+const needUpdateSet = new Set<string>();
 const updateCache = new UpdateCache();
 const updateInfo = new UpdateInfo();
-const workspaceConfig: WorkspaceConfig = new WorkspaceConfig();
+const workspaceConfig = new WorkspaceConfig();
 
 export { needUpdateSet, updateCache, updateInfo, workspaceConfig };

--- a/src/web/entry/common.ts
+++ b/src/web/entry/common.ts
@@ -4,11 +4,8 @@ import { UpdateCache } from './UpdateCache';
 import { WorkspaceConfig } from './WorkspaceConfig';
 
 const needUpdateSet: Set<string> = new Set();
-
 const updateCache = new UpdateCache();
-
 const updateInfo = new UpdateInfo();
-
 const workspaceConfig: WorkspaceConfig = new WorkspaceConfig();
 
-export {needUpdateSet, updateCache, updateInfo, workspaceConfig};
+export { needUpdateSet, updateCache, updateInfo, workspaceConfig };

--- a/src/web/entry/init.ts
+++ b/src/web/entry/init.ts
@@ -73,7 +73,7 @@ function disposeAll(disposablesDict: Record<string, vscode.Disposable | undefine
   }
 }
 
-function initWithConfig(workspaceConfig: WorkspaceConfig, contextSubcriptions: vscode.Disposable[]) {
+function initWithConfig(contextSubcriptions: vscode.Disposable[]) {
   const saEnabled = initWorkspaceConfig(workspaceConfig, contextSubcriptions);
   if (saEnabled) {
     backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
@@ -250,9 +250,5 @@ function updateContextSubcriptions(
   }
 }
 
-export {
-  triggerUpdateSymbol,
-  initWithConfig,
-  workspaceConfig,
-};
+export { initWithConfig };
 

--- a/src/web/entry/init.ts
+++ b/src/web/entry/init.ts
@@ -274,5 +274,6 @@ function updateContextSubcriptions(
 export {
   triggerUpdateSymbol,
   initWithConfig,
+  workspaceConfig,
 };
 

--- a/src/web/entry/init.ts
+++ b/src/web/entry/init.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 
 import { CL_ID, CL_MODE } from '../cl_util';
-import { decideUpdateProcess, updateSymbol } from './listen_update';
+import { decideUpdateProcess, triggerUpdateSymbol, updateSymbol } from './listen_update';
 import { getProvider } from './provider_manager';
 
 import { WorkspaceConfig } from './WorkspaceConfig';
@@ -63,26 +63,6 @@ function debounceTriggerUpdateSymbol(doc: vscode.TextDocument) {
 
   timerId = setTimeout(() => { updateSymbol(doc); }, debounceTimeout);
   return;
-}
-
-
-function triggerUpdateSymbol(doc: vscode.TextDocument) {
-  const throttleTimeout = workspaceConfig.config['commonLisp.Updater.throttleTimeout'] || 200;
-
-  if (updateTimeStamp === undefined) {
-    updateTimeStamp = performance.now();
-    updateSymbol(doc);
-    return;
-  }
-
-  if (performance.now() - updateTimeStamp < throttleTimeout) {
-    //console.log('throttle@@@@@@@@@@@')
-    return;
-  } else {
-    updateTimeStamp = performance.now();
-    updateSymbol(doc);
-    return;
-  }
 }
 
 function disposeAll(disposablesDict: Record<string, vscode.Disposable | undefined>) {

--- a/src/web/entry/init.ts
+++ b/src/web/entry/init.ts
@@ -10,7 +10,6 @@ import { needUpdateSet, workspaceConfig } from './common';
 
 let activeEditor = vscode.window.activeTextEditor;
 let timerId: NodeJS.Timer | undefined = undefined;
-let updateTimeStamp: number | undefined = undefined;
 
 // in case both 
 // DocumentSemanticTokensProvider and DocumentSymbolProvider are NOT enabled
@@ -80,7 +79,7 @@ function initWithConfig(workspaceConfig: WorkspaceConfig, contextSubcriptions: v
     backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
 
     needUpdateSet.clear();
-    decideUpdateProcess(workspaceConfig).forEach(needUpdateSet.add, needUpdateSet);
+    decideUpdateProcess().forEach(needUpdateSet.add, needUpdateSet);
 
     if (
       workspaceConfig.disposables['documentSemanticTokensProvider'] === undefined &&
@@ -100,7 +99,7 @@ function initWithConfig(workspaceConfig: WorkspaceConfig, contextSubcriptions: v
     backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
 
     needUpdateSet.clear();
-    decideUpdateProcess(workspaceConfig).forEach(needUpdateSet.add, needUpdateSet);
+    decideUpdateProcess().forEach(needUpdateSet.add, needUpdateSet);
   }, contextSubcriptions);
 }
 
@@ -144,7 +143,7 @@ function updateWorkspaceConfig(
       backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
 
       needUpdateSet.clear();
-      decideUpdateProcess(workspaceConfig).forEach(needUpdateSet.add, needUpdateSet);
+      decideUpdateProcess().forEach(needUpdateSet.add, needUpdateSet);
 
       if (
         workspaceConfig.disposables['documentSemanticTokensProvider'] === undefined &&

--- a/src/web/entry/init.ts
+++ b/src/web/entry/init.ts
@@ -6,13 +6,11 @@ import { getProvider } from './provider_manager';
 
 import { WorkspaceConfig } from './WorkspaceConfig';
 
+import { needUpdateSet, workspaceConfig } from './common';
+
 let activeEditor = vscode.window.activeTextEditor;
 let timerId: NodeJS.Timer | undefined = undefined;
 let updateTimeStamp: number | undefined = undefined;
-
-const workspaceConfig: WorkspaceConfig = new WorkspaceConfig();
-
-let needUpdateSet: Set<string> = new Set();
 
 // in case both 
 // DocumentSemanticTokensProvider and DocumentSymbolProvider are NOT enabled
@@ -101,7 +99,8 @@ function initWithConfig(workspaceConfig: WorkspaceConfig, contextSubcriptions: v
   if (saEnabled) {
     backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
 
-    needUpdateSet = decideUpdateProcess(workspaceConfig);
+    needUpdateSet.clear();
+    decideUpdateProcess(workspaceConfig).forEach(needUpdateSet.add, needUpdateSet);
 
     if (
       workspaceConfig.disposables['documentSemanticTokensProvider'] === undefined &&
@@ -120,7 +119,8 @@ function initWithConfig(workspaceConfig: WorkspaceConfig, contextSubcriptions: v
     }
     backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
 
-    needUpdateSet = decideUpdateProcess(workspaceConfig);
+    needUpdateSet.clear();
+    decideUpdateProcess(workspaceConfig).forEach(needUpdateSet.add, needUpdateSet);
   }, contextSubcriptions);
 }
 
@@ -163,7 +163,8 @@ function updateWorkspaceConfig(
       initWorkspaceConfig(workspaceConfig, contextSubcriptions);
       backupTriggerUpdateSymbol(workspaceConfig, contextSubcriptions);
 
-      needUpdateSet = decideUpdateProcess(workspaceConfig);
+      needUpdateSet.clear();
+      decideUpdateProcess(workspaceConfig).forEach(needUpdateSet.add, needUpdateSet);
 
       if (
         workspaceConfig.disposables['documentSemanticTokensProvider'] === undefined &&
@@ -273,7 +274,5 @@ function updateContextSubcriptions(
 export {
   triggerUpdateSymbol,
   initWithConfig,
-  workspaceConfig,
-  needUpdateSet
 };
 

--- a/src/web/entry/listen_update.ts
+++ b/src/web/entry/listen_update.ts
@@ -102,6 +102,25 @@ function updateSymbol(doc: vscode.TextDocument) {
   //console.log(`finish: ${performance.now() - t}ms`);
 }
 
+function triggerUpdateSymbol(doc: vscode.TextDocument) {
+  const throttleTimeout = workspaceConfig.config['commonLisp.Updater.throttleTimeout'] || 200;
+
+  if (updateTimeStamp === undefined) {
+    updateTimeStamp = performance.now();
+    updateSymbol(doc);
+    return;
+  }
+
+  if (performance.now() - updateTimeStamp < throttleTimeout) {
+    //console.log('throttle@@@@@@@@@@@')
+    return;
+  } else {
+    updateTimeStamp = performance.now();
+    updateSymbol(doc);
+    return;
+  }
+}
+
 function _sleep(timer: number) {
   return new Promise<void>(resolve => {
     setTimeout(function () { resolve(); }, timer);
@@ -111,5 +130,6 @@ function _sleep(timer: number) {
 export {
   decideUpdateProcess,
   updateSymbol,
+  triggerUpdateSymbol,
 };
 

--- a/src/web/entry/listen_update.ts
+++ b/src/web/entry/listen_update.ts
@@ -5,11 +5,9 @@ import { getDocSymbolInfo } from '../user_symbol/user_symbol_interface';
 import { genUserSymbols } from '../comp_item_provider/comp_item_user_builder';
 import { buildSemanticTokens, genAllPossibleWord } from '../semantic_provider/semantic_tokens_builder';
 import { genAllCallHierarchyItems } from '../call_hierarchy_provider/call_hierarchy_builder';
-import { UpdateInfo } from './UpdateInfo';
-import { UpdateCache } from './UpdateCache';
 
 import { WorkspaceConfig } from './WorkspaceConfig';
-import { needUpdateSet } from './init';
+import { needUpdateSet, updateCache, updateInfo } from './common';
 
 function decideUpdateProcess(workspaceConfig: WorkspaceConfig): Set<string> {
   const need: Set<string> = new Set();
@@ -62,9 +60,6 @@ function decideUpdateProcess(workspaceConfig: WorkspaceConfig): Set<string> {
   return need;
 }
 
-let updateInfo = new UpdateInfo();
-let updateCache = new UpdateCache();
-
 // @sideEffect: UpdateInfo.currDocSymbolInfo: DocSymbolInfo | undefined
 // @sideEffect: UpdateInfo.currDocumentSymbol: vscode.DocumentSymbol[]
 // @sideEffect: UpdateInfo.currUserSymbols: vscode.CompletionItem[]
@@ -73,8 +68,8 @@ let updateCache = new UpdateCache();
 function updateSymbol(doc: vscode.TextDocument) {
   //const t = performance.now();
 
-  updateCache = new UpdateCache();
-  updateInfo = new UpdateInfo();
+  updateCache.reset();
+  updateInfo.reset();
   // order matters here!
 
   if (needUpdateSet.has('getDocSymbolInfo')) {
@@ -116,6 +111,5 @@ function _sleep(timer: number) {
 export {
   decideUpdateProcess,
   updateSymbol,
-  updateInfo,
 };
 

--- a/src/web/entry/listen_update.ts
+++ b/src/web/entry/listen_update.ts
@@ -7,9 +7,9 @@ import { buildSemanticTokens, genAllPossibleWord } from '../semantic_provider/se
 import { genAllCallHierarchyItems } from '../call_hierarchy_provider/call_hierarchy_builder';
 
 import { WorkspaceConfig } from './WorkspaceConfig';
-import { needUpdateSet, updateCache, updateInfo } from './common';
+import { needUpdateSet, updateCache, updateInfo, workspaceConfig } from './common';
 
-function decideUpdateProcess(workspaceConfig: WorkspaceConfig): Set<string> {
+function decideUpdateProcess(): Set<string> {
   const need: Set<string> = new Set();
   if (
     workspaceConfig.disposables['userCompletionItemProvider'] !== undefined ||
@@ -102,6 +102,7 @@ function updateSymbol(doc: vscode.TextDocument) {
   //console.log(`finish: ${performance.now() - t}ms`);
 }
 
+let updateTimeStamp: number | undefined = undefined;
 function triggerUpdateSymbol(doc: vscode.TextDocument) {
   const throttleTimeout = workspaceConfig.config['commonLisp.Updater.throttleTimeout'] || 200;
 

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -2,15 +2,12 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
-import {
-  initWithConfig,
-  workspaceConfig
-} from './entry/init';
+import { initWithConfig } from './entry/init';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
-  initWithConfig(workspaceConfig, context.subscriptions);
+  initWithConfig(context.subscriptions);
 }
 
 // this method is called when your extension is deactivated

--- a/src/web/reference_provider/reference_provider.ts
+++ b/src/web/reference_provider/reference_provider.ts
@@ -4,7 +4,7 @@ import { clValidWithColonSharp, CL_MODE } from '../cl_util';
 import { isQuote } from '../user_symbol/collect_symbol_util';
 import { getReferenceByWord } from './symbol_reference_builder';
 
-import { updateInfo } from '../entry/listen_update';
+import { updateInfo } from '../entry/common';
 
 function getReferenceProvider() {
   const referenceProvider = vscode.languages.registerReferenceProvider(

--- a/src/web/reference_provider/symbol_reference_builder.ts
+++ b/src/web/reference_provider/symbol_reference_builder.ts
@@ -5,8 +5,7 @@ import { isRangeIntExcludedRanges, isQuote, isShadowed, isIntExcludedRanges } fr
 import { SymbolInfo } from '../user_symbol/SymbolInfo';
 import { bisectRight } from '../algorithm';
 
-import { updateInfo } from '../entry/listen_update';
-import { workspaceConfig } from '../entry/common';
+import { updateInfo, workspaceConfig } from '../entry/common';
 
 // Design options: include? definition, include? comment, include? string
 // See https://github.com/microsoft/vscode/issues/74237

--- a/src/web/reference_provider/symbol_reference_builder.ts
+++ b/src/web/reference_provider/symbol_reference_builder.ts
@@ -6,7 +6,7 @@ import { SymbolInfo } from '../user_symbol/SymbolInfo';
 import { bisectRight } from '../algorithm';
 
 import { updateInfo } from '../entry/listen_update';
-import { workspaceConfig } from '../entry/init';
+import { workspaceConfig } from '../entry/common';
 
 // Design options: include? definition, include? comment, include? string
 // See https://github.com/microsoft/vscode/issues/74237

--- a/src/web/semantic_provider/semantic_provider.ts
+++ b/src/web/semantic_provider/semantic_provider.ts
@@ -4,7 +4,7 @@ import { CL_MODE } from '../cl_util';
 import { legend } from './semantic_tokens_builder';
 
 import { updateInfo } from '../entry/common';
-import { triggerUpdateSymbol } from '../entry/init';
+import { triggerUpdateSymbol } from '../entry/listen_update';
 
 function getSemanticProvider() {
   const semanticProvider = vscode.languages.registerDocumentSemanticTokensProvider(

--- a/src/web/semantic_provider/semantic_provider.ts
+++ b/src/web/semantic_provider/semantic_provider.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import { CL_MODE } from '../cl_util';
 import { legend } from './semantic_tokens_builder';
 
-import { updateInfo } from '../entry/listen_update';
+import { updateInfo } from '../entry/common';
 import { triggerUpdateSymbol } from '../entry/init';
 
 function getSemanticProvider() {

--- a/src/web/semantic_provider/semantic_tokens_builder.ts
+++ b/src/web/semantic_provider/semantic_tokens_builder.ts
@@ -7,7 +7,7 @@ import { ParsedToken } from './ParsedToken';
 import { SingleQuoteAndBackQuoteHighlight } from '../entry/WorkspaceConfig';
 
 import { updateInfo } from '../entry/listen_update';
-import { workspaceConfig } from '../entry/init';
+import { workspaceConfig } from '../entry/common';
 
 const tokenTypes = new Map<string, number>();
 const tokenModifiers = new Map<string, number>();

--- a/src/web/semantic_provider/semantic_tokens_builder.ts
+++ b/src/web/semantic_provider/semantic_tokens_builder.ts
@@ -6,8 +6,7 @@ import { bisectRight, excludeRangesFromRanges, mergeSortedIntervals } from '../a
 import { ParsedToken } from './ParsedToken';
 import { SingleQuoteAndBackQuoteHighlight } from '../entry/WorkspaceConfig';
 
-import { updateInfo } from '../entry/listen_update';
-import { workspaceConfig } from '../entry/common';
+import { updateInfo, workspaceConfig } from '../entry/common';
 
 const tokenTypes = new Map<string, number>();
 const tokenModifiers = new Map<string, number>();

--- a/src/web/user_symbol/user_symbol_interface.ts
+++ b/src/web/user_symbol/user_symbol_interface.ts
@@ -7,7 +7,7 @@ import { DocSymbolInfo } from './DocSymbolInfo';
 import { mergeSortedMXArr, mergeSortedIntervals, excludeRangesFromRanges } from '../algorithm';
 import { SingleQuoteAndBackQuoteExcludedRanges } from '../entry/WorkspaceConfig';
 
-import { workspaceConfig } from '../entry/init';
+import { workspaceConfig } from '../entry/common';
 
 function getDocSymbolInfo(document: vscode.TextDocument) {
 


### PR DESCRIPTION
`entry/init.ts` is the main entry point from `extension.ts` but it also exports a few methods used by the rest of the project.

This means that it has a few circular dependencies which cause problems with some build systems when using this extension with other vscode based projects.

I think it could potentially make this code a bit easier to follow if there was a non-circular dependency graph. This is done by removing all dependencies on `init.ts` other than from `extension.ts` and it moves a lot of the basic common logic out of `listen_updates.ts` and into a new file.