### PR TITLE
vscode use `lisp` instead of `commonlisp` for its language specifier.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The language identifier (id) is `commonlisp` .
 
 If you need to customize your setting only for Common Lisp files, in `settings.json`, please add something like
 ```json
-"[commonlisp]": {
+"[lisp]": {
   "editor.bracketPairColorization.enabled": false
 }
 ```


### PR DESCRIPTION
use `lisp` instead of the other for language-specific brackets colorization to work correctly.
<img width="1511" alt="image" src="https://github.com/qingpeng9802/vscode-common-lisp/assets/18750154/a350bee1-62f8-490a-9d7d-d89e7708f01a">
